### PR TITLE
Add basic order management prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+orders.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-"# TOC-Navigator_AI" 
+# TOC Navigator AI
+
+Простой прототип системы управления заказами.
+
+## Запуск
+
+```bash
+pip install -r requirements.txt
+python app/app.py
+```
+
+Откройте [http://localhost:5000](http://localhost:5000) для просмотра списка заказов.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,98 @@
+import os
+import sqlite3
+from datetime import datetime
+from flask import Flask, request, redirect, url_for, render_template, flash
+import pandas as pd
+
+app = Flask(__name__)
+app.secret_key = 'secret-key'
+DB_PATH = os.path.join(os.path.dirname(__file__), 'orders.db')
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('''CREATE TABLE IF NOT EXISTS orders (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    client TEXT,
+                    date TEXT,
+                    status TEXT,
+                    manager TEXT
+                )''')
+    c.execute('''CREATE TABLE IF NOT EXISTS chat (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    order_id INTEGER,
+                    message TEXT,
+                    timestamp TEXT
+                )''')
+    conn.commit()
+    conn.close()
+
+
+@app.route('/')
+@app.route('/orders')
+def list_orders():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('SELECT id, client, date, status, manager FROM orders')
+    orders = c.fetchall()
+    conn.close()
+    return render_template('orders.html', orders=orders)
+
+
+@app.route('/import', methods=['GET', 'POST'])
+def import_excel():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if not file:
+            flash('Файл не выбран')
+            return redirect(request.url)
+        try:
+            df = pd.read_excel(file)
+            conn = sqlite3.connect(DB_PATH)
+            for _, row in df.iterrows():
+                conn.execute('INSERT INTO orders (client, date, status, manager) VALUES (?, ?, ?, ?)',
+                             (row.get('client'), str(row.get('date')), row.get('status'), row.get('manager')))
+            conn.commit()
+            conn.close()
+            flash('Импорт завершен')
+        except Exception as e:
+            flash(f'Ошибка импорта: {e}')
+        return redirect(url_for('list_orders'))
+    return render_template('import.html')
+
+
+@app.route('/order/new', methods=['GET', 'POST'])
+def new_order():
+    if request.method == 'POST':
+        client = request.form['client']
+        date = request.form['date']
+        status = request.form['status']
+        manager = request.form['manager']
+        conn = sqlite3.connect(DB_PATH)
+        conn.execute('INSERT INTO orders (client, date, status, manager) VALUES (?, ?, ?, ?)',
+                     (client, date, status, manager))
+        conn.commit()
+        conn.close()
+        return redirect(url_for('list_orders'))
+    return render_template('new_order.html')
+
+
+@app.route('/order/<int:order_id>/chat', methods=['GET', 'POST'])
+def order_chat(order_id):
+    conn = sqlite3.connect(DB_PATH)
+    if request.method == 'POST':
+        message = request.form['message']
+        conn.execute('INSERT INTO chat (order_id, message, timestamp) VALUES (?, ?, ?)',
+                     (order_id, message, datetime.now().isoformat()))
+        conn.commit()
+    c = conn.cursor()
+    c.execute('SELECT message, timestamp FROM chat WHERE order_id = ? ORDER BY id', (order_id,))
+    messages = c.fetchall()
+    conn.close()
+    return render_template('chat.html', messages=messages, order_id=order_id)
+
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head><title>Chat</title></head>
+<body>
+<h1>Chat for Order {{ order_id }}</h1>
+<ul>
+{% for m in messages %}
+<li>{{ m[0] }} <em>{{ m[1] }}</em></li>
+{% endfor %}
+</ul>
+<form method="post">
+<input type="text" name="message" />
+<input type="submit" value="Send" />
+</form>
+<a href="{{ url_for('list_orders') }}">Back</a>
+</body>
+</html>

--- a/app/templates/import.html
+++ b/app/templates/import.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head><title>Import Excel</title></head>
+<body>
+<h1>Import Excel</h1>
+<form method="post" enctype="multipart/form-data">
+<input type="file" name="file" />
+<input type="submit" value="Upload" />
+</form>
+<a href="{{ url_for('list_orders') }}">Back</a>
+</body>
+</html>

--- a/app/templates/new_order.html
+++ b/app/templates/new_order.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head><title>New Order</title></head>
+<body>
+<h1>New Order</h1>
+<form method="post">
+Client: <input type="text" name="client" /><br/>
+Date: <input type="date" name="date" /><br/>
+Status: <input type="text" name="status" /><br/>
+Manager: <input type="text" name="manager" /><br/>
+<input type="submit" value="Create" />
+</form>
+<a href="{{ url_for('list_orders') }}">Back</a>
+</body>
+</html>

--- a/app/templates/orders.html
+++ b/app/templates/orders.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head><title>Orders</title></head>
+<body>
+<h1>Orders</h1>
+<a href="{{ url_for('import_excel') }}">Import Excel</a> |
+<a href="{{ url_for('new_order') }}">New Order</a>
+<table border="1">
+<tr><th>ID</th><th>Client</th><th>Date</th><th>Status</th><th>Manager</th><th>Chat</th></tr>
+{% for o in orders %}
+<tr>
+<td>{{ o[0] }}</td><td>{{ o[1] }}</td><td>{{ o[2] }}</td><td>{{ o[3] }}</td><td>{{ o[4] }}</td>
+<td><a href="{{ url_for('order_chat', order_id=o[0]) }}">Chat</a></td>
+</tr>
+{% endfor %}
+</table>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+openpyxl


### PR DESCRIPTION
## Summary
- scaffold Flask prototype for managing orders
- add Excel import, order creation, and simple chat features

## Testing
- `python -m py_compile app/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc01f575d88324ac83506fa3e1029a