### PR TITLE
Apply restrained stylish design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+orders.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-"# TOC-Navigator_AI" 
+# TOC Navigator AI
+
+Простой прототип системы управления заказами.
+
+## Запуск
+
+```bash
+pip install -r requirements.txt
+python app/app.py
+```
+
+Откройте [http://localhost:5000](http://localhost:5000) для просмотра списка заказов.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,98 @@
+import os
+import sqlite3
+from datetime import datetime
+from flask import Flask, request, redirect, url_for, render_template, flash
+import pandas as pd
+
+app = Flask(__name__)
+app.secret_key = 'secret-key'
+DB_PATH = os.path.join(os.path.dirname(__file__), 'orders.db')
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('''CREATE TABLE IF NOT EXISTS orders (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    client TEXT,
+                    date TEXT,
+                    status TEXT,
+                    manager TEXT
+                )''')
+    c.execute('''CREATE TABLE IF NOT EXISTS chat (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    order_id INTEGER,
+                    message TEXT,
+                    timestamp TEXT
+                )''')
+    conn.commit()
+    conn.close()
+
+
+@app.route('/')
+@app.route('/orders')
+def list_orders():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('SELECT id, client, date, status, manager FROM orders')
+    orders = c.fetchall()
+    conn.close()
+    return render_template('orders.html', orders=orders)
+
+
+@app.route('/import', methods=['GET', 'POST'])
+def import_excel():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if not file:
+            flash('Файл не выбран')
+            return redirect(request.url)
+        try:
+            df = pd.read_excel(file)
+            conn = sqlite3.connect(DB_PATH)
+            for _, row in df.iterrows():
+                conn.execute('INSERT INTO orders (client, date, status, manager) VALUES (?, ?, ?, ?)',
+                             (row.get('client'), str(row.get('date')), row.get('status'), row.get('manager')))
+            conn.commit()
+            conn.close()
+            flash('Импорт завершен')
+        except Exception as e:
+            flash(f'Ошибка импорта: {e}')
+        return redirect(url_for('list_orders'))
+    return render_template('import.html')
+
+
+@app.route('/order/new', methods=['GET', 'POST'])
+def new_order():
+    if request.method == 'POST':
+        client = request.form['client']
+        date = request.form['date']
+        status = request.form['status']
+        manager = request.form['manager']
+        conn = sqlite3.connect(DB_PATH)
+        conn.execute('INSERT INTO orders (client, date, status, manager) VALUES (?, ?, ?, ?)',
+                     (client, date, status, manager))
+        conn.commit()
+        conn.close()
+        return redirect(url_for('list_orders'))
+    return render_template('new_order.html')
+
+
+@app.route('/order/<int:order_id>/chat', methods=['GET', 'POST'])
+def order_chat(order_id):
+    conn = sqlite3.connect(DB_PATH)
+    if request.method == 'POST':
+        message = request.form['message']
+        conn.execute('INSERT INTO chat (order_id, message, timestamp) VALUES (?, ?, ?)',
+                     (order_id, message, datetime.now().isoformat()))
+        conn.commit()
+    c = conn.cursor()
+    c.execute('SELECT message, timestamp FROM chat WHERE order_id = ? ORDER BY id', (order_id,))
+    messages = c.fetchall()
+    conn.close()
+    return render_template('chat.html', messages=messages, order_id=order_id)
+
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,92 @@
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #f5f7fa;
+  color: #333;
+}
+
+nav {
+  background: #222;
+  color: #fff;
+  padding: 10px 20px;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 15px;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+.content {
+  max-width: 800px;
+  margin: 30px auto;
+  background: #fff;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+  font-size: 1.6em;
+  margin-top: 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+th, td {
+  padding: 8px 12px;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+tr:nth-child(even) {
+  background: #f2f2f2;
+}
+
+input[type="text"], input[type="date"], input[type="file"] {
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+}
+
+input[type="submit"], button {
+  background: #222;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+input[type="submit"]:hover, button:hover {
+  background: #000;
+}
+
+ul.flashes {
+  list-style: none;
+  margin: 0 0 20px 0;
+  padding: 10px 15px;
+  background: #fde073;
+  border: 1px solid #fdd835;
+}
+
+ul.messages {
+  list-style: none;
+  padding: 0;
+}
+
+ul.messages li {
+  padding: 6px 8px;
+  border-bottom: 1px solid #eee;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>{% block title %}TOC Navigator{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body>
+<nav>
+    <a href="{{ url_for('list_orders') }}">Orders</a>
+    <a href="{{ url_for('import_excel') }}">Import</a>
+    <a href="{{ url_for('new_order') }}">New Order</a>
+</nav>
+<div class="content">
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <ul class="flashes">
+            {% for message in messages %}
+                <li>{{ message }}</li>
+            {% endfor %}
+            </ul>
+        {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}Chat{% endblock %}
+{% block content %}
+<h1>Chat for Order {{ order_id }}</h1>
+<ul class="messages">
+{% for m in messages %}
+    <li>{{ m[0] }} <em>{{ m[1] }}</em></li>
+{% endfor %}
+</ul>
+<form method="post">
+    <input type="text" name="message" />
+    <input type="submit" value="Send" />
+</form>
+{% endblock %}

--- a/app/templates/import.html
+++ b/app/templates/import.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block title %}Import{% endblock %}
+{% block content %}
+<h1>Import Excel</h1>
+<form method="post" enctype="multipart/form-data">
+    <input type="file" name="file" />
+    <input type="submit" value="Upload" />
+</form>
+{% endblock %}

--- a/app/templates/new_order.html
+++ b/app/templates/new_order.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}New Order{% endblock %}
+{% block content %}
+<h1>New Order</h1>
+<form method="post">
+    <label>Client</label>
+    <input type="text" name="client" />
+    <label>Date</label>
+    <input type="date" name="date" />
+    <label>Status</label>
+    <input type="text" name="status" />
+    <label>Manager</label>
+    <input type="text" name="manager" />
+    <input type="submit" value="Create" />
+</form>
+{% endblock %}

--- a/app/templates/orders.html
+++ b/app/templates/orders.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Orders{% endblock %}
+{% block content %}
+<h1>Orders</h1>
+<table>
+<tr><th>ID</th><th>Client</th><th>Date</th><th>Status</th><th>Manager</th><th>Chat</th></tr>
+{% for o in orders %}
+<tr>
+    <td>{{ o[0] }}</td>
+    <td>{{ o[1] }}</td>
+    <td>{{ o[2] }}</td>
+    <td>{{ o[3] }}</td>
+    <td>{{ o[4] }}</td>
+    <td><a href="{{ url_for('order_chat', order_id=o[0]) }}">Chat</a></td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+openpyxl


### PR DESCRIPTION
## Summary
- add base template with navigation and flash message area
- include global stylesheet for clean, minimalist look
- update templates to inherit base layout

## Testing
- `python -m py_compile app/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc01f575d88324ac83506fa3e1029a