### PR TITLE
Use .env-based configuration for Flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 orders.db
+.env

--- a/app/app.py
+++ b/app/app.py
@@ -1,12 +1,13 @@
-import os
 import sqlite3
 from datetime import datetime
 from flask import Flask, request, redirect, url_for, render_template, flash
 import pandas as pd
+from config import SECRET_KEY, DATABASE_URI, API_KEY
 
 app = Flask(__name__)
-app.secret_key = 'secret-key'
-DB_PATH = os.path.join(os.path.dirname(__file__), 'orders.db')
+app.secret_key = SECRET_KEY
+app.config['API_KEY'] = API_KEY
+DB_PATH = DATABASE_URI
 
 
 def init_db():

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+BASE_DIR = Path(__file__).resolve().parent
+load_dotenv(BASE_DIR.parent / ".env")
+
+
+SECRET_KEY = os.getenv("SECRET_KEY", "secret-key")
+
+# Path or URI to the SQLite database file
+DATABASE_URI = os.getenv("DATABASE_URI", str(BASE_DIR / "orders.db"))
+
+# Placeholder for external service access
+API_KEY = os.getenv("API_KEY")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 pandas
 openpyxl
+python-dotenv


### PR DESCRIPTION
## Summary
- ignore local `.env` file and declare python-dotenv dependency
- add a configuration module loading SECRET_KEY, DATABASE_URI, and API_KEY from `.env`
- initialize Flask app with values from the new config

## Testing
- `pip install python-dotenv` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc078721e883248e65eb145056c8e9