### PR TITLE
docs: add development plan

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,0 +1,31 @@
+# Software Development Plan — TOC Navigator AI Backend Prototype
+
+## 1. Foundation Setup
+- Docker Compose brings up FastAPI API, PostgreSQL, Qdrant, Redis.
+- Base project structure with linting, tests, and CI.
+
+## 2. Order Management Core
+- SQLAlchemy models and Alembic migrations for orders and operators.
+- CRUD endpoints for `/orders` and `/operators`.
+- Excel import endpoint with column validation.
+- Unit and integration tests.
+
+## 3. Event Logging & Vector Store
+- Event model and endpoints to log text updates on orders.
+- Background task generates embeddings and stores them in Qdrant.
+- Search endpoint for similar events.
+
+## 4. AI Assistance Layer
+- Retrieval-augmented generation service querying Qdrant.
+- Endpoint `POST /ai/advise` returning contextual recommendations from Gemini.
+
+## 5. KPI & Document Services
+- KPI calculation module and `GET /kpi` endpoint.
+- PDF upload/download endpoints with metadata storage.
+
+## Milestones
+1. **Week 2** – Development environment and CI running.
+2. **Week 8** – Stable CRUD and import interfaces.
+3. **Week 12** – Event logging and semantic search.
+4. **Week 16** – AI recommendations functional.
+5. **Week 20** – KPI dashboard and document management ready.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # TOC Navigator AI
 
-Простой прототип системы управления заказами.
+Простой прототип серверной части на FastAPI.
 
 ## Запуск
 
 ```bash
 pip install -r requirements.txt
-python app/app.py
+uvicorn app.main:app --reload
 ```
 
-Откройте [http://localhost:5000](http://localhost:5000) для просмотра списка заказов.
+Откройте [http://localhost:8000/docs](http://localhost:8000/docs) для просмотра API.
+
+Старый прототип на Flask сохранён в `app/legacy_app.py`.


### PR DESCRIPTION
## Summary
- add development plan outlining phases and milestones
- update README with FastAPI startup instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc05ead23c8324bbae7a648b65343c