### PR TITLE
Add Stage 1 skeleton with Docker, env setup, frontend and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+SECRET_KEY=change-me
+GEMINI_API_KEY=your-gemini-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          pre-commit install --install-hooks
+      - name: Lint
+        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Test
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 orders.db
+.env
+test.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
+    hooks:
+      - id: ruff
+        args: ["--fix"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/database.py
+++ b/app/database.py
@@ -1,10 +1,15 @@
 import os
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import declarative_base, sessionmaker
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
+load_dotenv()
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/postgres",
+)
 
-engine = create_engine(DATABASE_URL)
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+  qdrant:
+    image: qdrant/qdrant
+    ports:
+      - "6333:6333"
+  backend:
+    build: .
+    env_file: .env
+    depends_on:
+      - db
+      - qdrant
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+    ports:
+      - "5173:5173"
+volumes:
+  db-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package.json
+COPY tsconfig.json tsconfig.json
+COPY vite.config.ts vite.config.ts
+COPY index.html index.html
+COPY src src
+RUN npm install
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Orders App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.11",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import Login from './components/Login';
+import OrdersTable from './components/OrdersTable';
+import UploadModal from './components/UploadModal';
+
+export default function App() {
+  const [token, setToken] = useState<string | null>(null);
+  const [showModal, setShowModal] = useState(false);
+
+  if (!token) {
+    return <Login onLogin={(t) => setToken(t)} />;
+  }
+
+  return (
+    <div>
+      <button onClick={() => setShowModal(true)}>Import Excel</button>
+      <OrdersTable token={token} />
+      {showModal && <UploadModal token={token} onClose={() => setShowModal(false)} />}
+    </div>
+  );
+}

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onLogin: (token: string) => void;
+}
+
+export default function Login({ onLogin }: Props) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onLogin('fake-token');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/frontend/src/components/OrdersTable.tsx
+++ b/frontend/src/components/OrdersTable.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface Props {
+  token: string;
+}
+
+interface Order {
+  id: number;
+  item: string;
+  quantity: number;
+}
+
+export default function OrdersTable({ token }: Props) {
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    axios.get('/api/orders').then((res) => setOrders(res.data));
+  }, []);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Item</th>
+          <th>Quantity</th>
+        </tr>
+      </thead>
+      <tbody>
+        {orders.map((o) => (
+          <tr key={o.id}>
+            <td>{o.id}</td>
+            <td>{o.item}</td>
+            <td>{o.quantity}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+interface Props {
+  token: string;
+  onClose: () => void;
+}
+
+export default function UploadModal({ token, onClose }: Props) {
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleUpload = async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('file', file);
+    await axios.post('/api/orders/import-excel', form);
+    onClose();
+  };
+
+  return (
+    <div>
+      <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+      <button onClick={handleUpload}>Upload</button>
+      <button onClick={onClose}>Close</button>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://backend:8000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+});

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+pytest
+httpx
+pytest-asyncio
+pre-commit
+black
+ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ uvicorn
 sqlalchemy
 alembic
 psycopg2-binary
+python-dotenv

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,64 @@
+import io
+
+import pandas as pd
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.database import Base, get_db
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+client = TestClient(app)
+
+
+def test_order_crud():
+    resp = client.post("/orders/", json={"item": "Widget", "quantity": 2})
+    assert resp.status_code == 201
+    order_id = resp.json()["id"]
+
+    resp = client.get("/orders/")
+    assert resp.status_code == 200
+    assert any(o["id"] == order_id for o in resp.json())
+
+    resp = client.put(f"/orders/{order_id}", json={"quantity": 5})
+    assert resp.status_code == 200
+    assert resp.json()["quantity"] == 5
+
+    resp = client.delete(f"/orders/{order_id}")
+    assert resp.status_code == 204
+
+
+def test_import_excel():
+    df = pd.DataFrame([{ "item": "Sprocket", "quantity": 3 }])
+    stream = io.BytesIO()
+    df.to_excel(stream, index=False)
+    stream.seek(0)
+    files = {
+        "file": (
+            "orders.xlsx",
+            stream.read(),
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    }
+    resp = client.post("/orders/import-excel", files=files)
+    assert resp.status_code == 201
+    assert resp.json()["inserted"] == 1


### PR DESCRIPTION
## Summary
- scaffold Docker environment for Postgres, Qdrant, backend, and frontend
- wire database config through `.env` and add Excel import endpoint
- introduce Vite/React frontend skeleton and initial tests with CI

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pre-commit run --files app/database.py app/routers/orders.py tests/test_orders.py` *(fails: command not found: pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68bc0dd94b388324ab03272f94c4b7d4