### PR TITLE
Add Excel import endpoint and tests

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -4,7 +4,8 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
 
-engine = create_engine(DATABASE_URL)
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from .routers import orders, operators
+from .routers import orders, operators, import_excel
 from . import models
 from .database import engine
 
@@ -10,6 +10,7 @@ app = FastAPI()
 
 app.include_router(orders.router)
 app.include_router(operators.router)
+app.include_router(import_excel.router)
 
 
 if __name__ == "__main__":

--- a/app/routers/import_excel.py
+++ b/app/routers/import_excel.py
@@ -1,0 +1,60 @@
+from io import BytesIO
+from typing import Set
+
+import pandas as pd
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..database import get_db
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+REQUIRED_COLUMNS: Set[str] = {"item", "quantity"}
+
+
+@router.post("/excel")
+def import_orders_from_excel(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    try:
+        contents = file.file.read()
+        df = pd.read_excel(BytesIO(contents))
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid Excel file: {exc}")
+
+    missing = REQUIRED_COLUMNS - set(df.columns)
+    if missing:
+        raise HTTPException(
+            status_code=400, detail=f"Missing columns: {', '.join(sorted(missing))}"
+        )
+
+    created = 0
+    for _, row in df.iterrows():
+        operator_id = None
+        operator_name = row.get("operator")
+        if isinstance(operator_name, str) and operator_name:
+            operator = (
+                db.query(models.Operator)
+                .filter(models.Operator.name == operator_name)
+                .first()
+            )
+            if operator is None:
+                operator = models.Operator(name=operator_name)
+                db.add(operator)
+                db.commit()
+                db.refresh(operator)
+            operator_id = operator.id
+
+        order = models.Order(
+            item=row["item"],
+            quantity=int(row["quantity"]) if not pd.isna(row["quantity"]) else 1,
+            operator_id=operator_id,
+        )
+        db.add(order)
+        created += 1
+
+    db.commit()
+
+    return {"created": created}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ uvicorn
 sqlalchemy
 alembic
 psycopg2-binary
+python-multipart
+pytest

--- a/tests/test_import_excel.py
+++ b/tests/test_import_excel.py
@@ -1,0 +1,45 @@
+import os
+from io import BytesIO
+
+import pandas as pd
+from fastapi.testclient import TestClient
+
+# Use a temporary SQLite database for tests
+TEST_DB = "test.db"
+if os.path.exists(TEST_DB):
+    os.remove(TEST_DB)
+os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB}"
+
+from app.main import app  # noqa: E402  (import after setting env)
+from app.database import Base, engine  # noqa: E402
+
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+
+def test_import_excel_creates_orders_and_operators():
+    df = pd.DataFrame([
+        {"item": "Widget", "quantity": 2, "operator": "Alice"},
+        {"item": "Gadget", "quantity": 5, "operator": "Bob"},
+    ])
+    buffer = BytesIO()
+    df.to_excel(buffer, index=False)
+    buffer.seek(0)
+
+    response = client.post(
+        "/import/excel",
+        files={
+            "file": (
+                "orders.xlsx",
+                buffer,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["created"] == 2
+
+    orders_resp = client.get("/orders")
+    data = orders_resp.json()
+    assert len(data) == 2
+    assert {o["operator"]["name"] for o in data} == {"Alice", "Bob"}


### PR DESCRIPTION
## Summary
- add `/import/excel` endpoint to load orders from Excel
- allow SQLite connections by handling `check_same_thread`
- cover Excel import flow with basic test

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-multipart)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc104cf5b883248e5090543fcaef12