### PR TITLE
feat(frontend): scaffold React app with order management

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,2 +1,11 @@
+FROM node:18-alpine as build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
 FROM nginx:alpine
-COPY index.html /usr/share/nginx/html/index.html
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Frontend Scaffold</title>
-</head>
-<body>
-  <h1>Frontend Scaffold</h1>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TOC Navigator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react'
+import Login from './components/Login'
+import Orders from './components/Orders'
+
+export default function App() {
+  const [loggedIn, setLoggedIn] = useState(false)
+
+  return loggedIn ? (
+    <Orders />
+  ) : (
+    <Login onLogin={() => setLoggedIn(true)} />
+  )
+}

--- a/frontend/src/components/ExcelModal.jsx
+++ b/frontend/src/components/ExcelModal.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react'
+
+export default function ExcelModal({ open, onClose, onUploaded }) {
+  const [file, setFile] = useState(null)
+
+  function upload(e) {
+    e.preventDefault()
+    if (!file) return
+    const formData = new FormData()
+    formData.append('file', file)
+    fetch('/orders/import-excel', { method: 'POST', body: formData }).then(() => {
+      onUploaded && onUploaded()
+      setFile(null)
+      onClose()
+    })
+  }
+
+  if (!open) return null
+  return (
+    <div className="modal">
+      <form onSubmit={upload}>
+        <input
+          type="file"
+          accept=".xls,.xlsx"
+          onChange={(e) => setFile(e.target.files[0])}
+        />
+        <button type="submit">Upload</button>
+        <button type="button" onClick={onClose}>
+          Close
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react'
+
+export default function Login({ onLogin }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    if (username && password) {
+      onLogin()
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Login</h2>
+      <div>
+        <label>
+          Username
+          <input value={username} onChange={(e) => setUsername(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+      </div>
+      <button type="submit">Login</button>
+    </form>
+  )
+}

--- a/frontend/src/components/Orders.jsx
+++ b/frontend/src/components/Orders.jsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from 'react'
+import ExcelModal from './ExcelModal'
+
+function OrderRow({ order, onUpdate, onDelete }) {
+  const [editing, setEditing] = useState(false)
+  const [item, setItem] = useState(order.item)
+  const [quantity, setQuantity] = useState(order.quantity)
+
+  function save() {
+    onUpdate(order.id, { item, quantity: Number(quantity) })
+    setEditing(false)
+  }
+
+  return (
+    <tr>
+      <td>
+        {editing ? (
+          <input value={item} onChange={(e) => setItem(e.target.value)} />
+        ) : (
+          order.item
+        )}
+      </td>
+      <td>
+        {editing ? (
+          <input
+            type="number"
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value)}
+          />
+        ) : (
+          order.quantity
+        )}
+      </td>
+      <td>
+        {editing ? (
+          <button onClick={save}>Save</button>
+        ) : (
+          <button onClick={() => setEditing(true)}>Edit</button>
+        )}
+        <button onClick={() => onDelete(order.id)}>Delete</button>
+      </td>
+    </tr>
+  )
+}
+
+export default function Orders() {
+  const [orders, setOrders] = useState([])
+  const [item, setItem] = useState('')
+  const [quantity, setQuantity] = useState(1)
+  const [showModal, setShowModal] = useState(false)
+
+  useEffect(() => {
+    fetch('/orders')
+      .then((res) => res.json())
+      .then(setOrders)
+  }, [])
+
+  function refresh() {
+    fetch('/orders')
+      .then((res) => res.json())
+      .then(setOrders)
+  }
+
+  function createOrder(e) {
+    e.preventDefault()
+    fetch('/orders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ item, quantity: Number(quantity) }),
+    })
+      .then((res) => res.json())
+      .then((order) => setOrders([...orders, order]))
+    setItem('')
+    setQuantity(1)
+  }
+
+  function updateOrder(id, data) {
+    fetch(`/orders/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+      .then((res) => res.json())
+      .then((updated) =>
+        setOrders(orders.map((o) => (o.id === id ? updated : o)))
+      )
+  }
+
+  function deleteOrder(id) {
+    fetch(`/orders/${id}`, { method: 'DELETE' }).then(() =>
+      setOrders(orders.filter((o) => o.id !== id))
+    )
+  }
+
+  return (
+    <div>
+      <h2>Orders</h2>
+      <form onSubmit={createOrder}>
+        <input
+          value={item}
+          onChange={(e) => setItem(e.target.value)}
+          placeholder="Item"
+        />
+        <input
+          type="number"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+        />
+        <button type="submit">Add</button>
+      </form>
+      <button onClick={() => setShowModal(true)}>Import Excel</button>
+      <ExcelModal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        onUploaded={refresh}
+      />
+      <table>
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>Quantity</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((order) => (
+            <OrderRow
+              key={order.id}
+              order={order}
+              onUpdate={updateOrder}
+              onDelete={deleteOrder}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold Vite/React frontend with login screen and order table
- add CRUD and Excel upload modal wired to existing API
- include build tooling and Docker setup

## Testing
- `pytest` *(fails: RuntimeError: requires httpx package)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm test` *(fails: sh: 1: vitest: not found)*
- `pre-commit run --files frontend/package.json frontend/vite.config.js frontend/index.html frontend/src/main.jsx frontend/src/App.jsx frontend/src/components/Login.jsx frontend/src/components/ExcelModal.jsx frontend/src/components/Orders.jsx frontend/Dockerfile frontend/.gitignore` *(fails: command not found: pre-commit)*
- `pip install pre-commit` *(fails: No matching distribution found for pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68bc150672bc83248891c98522daeea1