### PR TITLE
Add order tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest -q

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 from pydantic import BaseModel
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,14 @@
 import os
+import sys
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
 TEST_DB = "test.db"
+
+# Ensure project root is on PYTHONPATH for `import app`
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB}"
 
 from app.main import app  # noqa: E402  (import after setting env)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+
+TEST_DB = "test.db"
+os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB}"
+
+from app.main import app  # noqa: E402  (import after setting env)
+from app.database import Base, engine  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    if os.path.exists(TEST_DB):
+        os.remove(TEST_DB)
+    Base.metadata.create_all(bind=engine)
+    with TestClient(app) as client:
+        yield client
+    engine.dispose()
+    if os.path.exists(TEST_DB):
+        os.remove(TEST_DB)

--- a/tests/test_import_excel.py
+++ b/tests/test_import_excel.py
@@ -1,27 +1,15 @@
-import os
 from io import BytesIO
 
 import pandas as pd
-from fastapi.testclient import TestClient
-
-# Use a temporary SQLite database for tests
-TEST_DB = "test.db"
-if os.path.exists(TEST_DB):
-    os.remove(TEST_DB)
-os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB}"
-
-from app.main import app  # noqa: E402  (import after setting env)
-from app.database import Base, engine  # noqa: E402
-
-Base.metadata.create_all(bind=engine)
-client = TestClient(app)
 
 
-def test_import_excel_creates_orders_and_operators():
-    df = pd.DataFrame([
-        {"item": "Widget", "quantity": 2, "operator": "Alice"},
-        {"item": "Gadget", "quantity": 5, "operator": "Bob"},
-    ])
+def test_import_excel_creates_orders_and_operators(client):
+    df = pd.DataFrame(
+        [
+            {"item": "Widget", "quantity": 2, "operator": "Alice"},
+            {"item": "Gadget", "quantity": 5, "operator": "Bob"},
+        ]
+    )
     buffer = BytesIO()
     df.to_excel(buffer, index=False)
     buffer.seek(0)
@@ -43,3 +31,23 @@ def test_import_excel_creates_orders_and_operators():
     data = orders_resp.json()
     assert len(data) == 2
     assert {o["operator"]["name"] for o in data} == {"Alice", "Bob"}
+
+
+def test_import_excel_missing_required_columns(client):
+    df = pd.DataFrame([{"item": "Widget"}])  # missing quantity column
+    buffer = BytesIO()
+    df.to_excel(buffer, index=False)
+    buffer.seek(0)
+
+    response = client.post(
+        "/orders/import-excel",
+        files={
+            "file": (
+                "orders.xlsx",
+                buffer,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
+        },
+    )
+    assert response.status_code == 400
+    assert "Missing columns" in response.json()["detail"]

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,53 @@
+
+def test_create_order(client):
+    response = client.post("/orders/", json={"item": "Widget", "quantity": 3})
+    assert response.status_code == 201
+    data = response.json()
+    assert data["item"] == "Widget"
+    assert data["quantity"] == 3
+
+
+def test_read_orders_returns_all_orders(client):
+    client.post("/orders/", json={"item": "Widget", "quantity": 3})
+    client.post("/orders/", json={"item": "Gadget", "quantity": 5})
+
+    response = client.get("/orders/")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert {order["item"] for order in data} == {"Widget", "Gadget"}
+
+
+def test_read_order_by_id(client):
+    created = client.post("/orders/", json={"item": "Widget", "quantity": 3}).json()
+    order_id = created["id"]
+
+    response = client.get(f"/orders/{order_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == order_id
+    assert data["item"] == "Widget"
+
+
+def test_update_order(client):
+    created = client.post("/orders/", json={"item": "Widget", "quantity": 3}).json()
+    order_id = created["id"]
+
+    response = client.put(
+        f"/orders/{order_id}", json={"item": "Gadget", "quantity": 5}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["item"] == "Gadget"
+    assert data["quantity"] == 5
+
+
+def test_delete_order(client):
+    created = client.post("/orders/", json={"item": "Widget", "quantity": 3}).json()
+    order_id = created["id"]
+
+    response = client.delete(f"/orders/{order_id}")
+    assert response.status_code == 204
+
+    response = client.get(f"/orders/{order_id}")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add fixtures and tests for order CRUD and Excel import validation
- set up GitHub Actions workflow for linting and tests
- remove unused import from schemas

## Testing
- `ruff check .`
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc170fc8d0832498057900df566b4f