### PR TITLE
Ensure routers declare FastAPI dependencies

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -1,9 +1,12 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
 from io import BytesIO
-from typing import List, Set
+from typing import Set
 
 import pandas as pd
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
-from sqlalchemy.orm import Session
+from fastapi import File, UploadFile
 
 from .. import models, schemas
 from ..database import get_db


### PR DESCRIPTION
## Summary
- reorder imports in orders router to explicitly import `List`, `APIRouter`, `Depends`, `HTTPException`, `status`, and `Session`
- confirm operators router already contained the necessary imports

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc27556db4832486f47a4ee4960b7e