### PR TITLE
chore: expand gitignore for env, logs and node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@ orders.db
 backend/.env
 frontend/.env
 legacy/.env
+*.log
 .venv
 __pycache__
-node_modules
+node_modules/
 dist
 build
 .DS_Store


### PR DESCRIPTION
## Summary
- ignore environment files, node modules directories and log files

## Testing
- `pre-commit run --files .gitignore` *(fails: command not found)*
- `pytest -q` *(fails: missing httpx dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68bc52c2789c8324975109db21c63738