### PR TITLE
refactor: isolate legacy flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,8 @@ __pycache__/
 *.pyc
 orders.db
 .env
-backend/.env
-frontend/.env
-legacy/.env
 *.log
 .venv
-__pycache__
 node_modules/
 dist
 build

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ docker-compose up --build
 
 Будут подняты сервисы `api`, `postgres`, `qdrant` и опционально `redis`. API будет доступен по адресу [http://localhost:8000/docs](http://localhost:8000/docs).
 
-Старый прототип на Flask сохранён в `app/legacy_app.py`.
+Старый прототип на Flask сохранён в `legacy/legacy_app.py`.

--- a/legacy/legacy_app.py
+++ b/legacy/legacy_app.py
@@ -1,14 +1,21 @@
 import os
 import sqlite3
 from datetime import datetime
+from pathlib import Path
+
 from flask import Flask, request, redirect, url_for, render_template, flash
-from dotenv import load_dotenv
 import pandas as pd
 
-load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+env_path = Path(__file__).with_name(".env")
+if env_path.exists():
+    for line in env_path.read_text().splitlines():
+        if line.startswith("SECRET_KEY="):
+            os.environ.setdefault("SECRET_KEY", line.split("=", 1)[1])
+            break
+
 app = Flask(__name__)
 app.secret_key = os.getenv("SECRET_KEY")
-DB_PATH = os.path.join(os.path.dirname(__file__), 'orders.db')
+DB_PATH = os.path.join(os.path.dirname(__file__), "orders.db")
 
 
 def init_db():

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ alembic
 psycopg2-binary
 python-multipart
 pytest
-python-dotenv


### PR DESCRIPTION
## Summary
- load SECRET_KEY for legacy Flask app from a local .env file without python-dotenv
- drop python-dotenv from requirements and ignore all .env files via .gitignore
- fix README to point to legacy/legacy_app.py

## Testing
- `pytest -q` *(fails: httpx missing and install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5560ac148324b1835327ab5da292