### PR TITLE
chore: ignore frontend env and log files

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,2 +1,4 @@
-node_modules
+node_modules/
 dist
+.env
+*.log


### PR DESCRIPTION
## Summary
- extend frontend .gitignore to cover .env and log files and ensure node_modules directories are skipped

## Testing
- `pip install --upgrade pip` *(failed: Could not connect to proxy)*
- `pip install -r requirements.txt` *(failed: Could not connect to proxy)*
- `pip install -r requirements-dev.txt` *(failed: Could not connect to proxy)*
- `pytest -q` *(failed: Missing dependency httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5765d6588324af9615bebb7bf9d7