### PR TITLE
feat: add docker and compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,14 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+
+EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -13,12 +13,19 @@ uvicorn app.main:app --reload
 
 ## Запуск в Docker
 
-Сборка и запуск всех контейнеров:
+Для локального запуска доступны контейнеры приложения и баз данных.
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
-Будут подняты сервисы `api`, `postgres`, `qdrant` и опционально `redis`. API будет доступен по адресу [http://localhost:8000/docs](http://localhost:8000/docs).
+Эта команда использует `docker-compose.yml` и поднимает сервисы `api`, `postgres` и `qdrant`.
+При необходимости Redis можно включить с помощью профиля:
+
+```bash
+docker compose --profile redis up --build
+```
+
+После старта API будет доступен по адресу [http://localhost:8000/docs](http://localhost:8000/docs).
 
 Старый прототип на Flask сохранён в `legacy/legacy_app.py`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     depends_on:
       - postgres
       - qdrant
-      # - redis  # uncomment if Redis is required
+      # - redis  # enable when the redis profile is used
+    restart: unless-stopped
   postgres:
     image: postgres:15
     restart: always
@@ -33,6 +34,8 @@ services:
     restart: always
     ports:
       - "6379:6379"
+    profiles:
+      - redis
 volumes:
   postgres_data:
   qdrant_data:


### PR DESCRIPTION
## Summary
- add production-ready Dockerfile exposing FastAPI
- configure docker-compose services for API, Postgres, Qdrant and optional Redis
- document container startup with optional Redis profile

## Testing
- `pytest -q` *(fails: httpx package missing and cannot be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5927dab483249e80d0fc2d65d233