### PR TITLE
docs: document Excel import route

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -103,6 +103,12 @@ def import_orders_from_excel(
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
 ):
+    """Import orders from an uploaded Excel file.
+
+    Each row is validated against ``OrderExcelRow`` and only valid rows
+    are persisted. Rows failing validation are returned in the ``errors``
+    list along with details about the failure.
+    """
     try:
         contents = file.file.read()
         df = pd.read_excel(BytesIO(contents))


### PR DESCRIPTION
## Summary
- document the `/orders/import-excel` endpoint that validates and imports orders from an uploaded Excel file

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5eb8228083248c59a1f981e59505